### PR TITLE
Remove usage of filelocks

### DIFF
--- a/burpa/__version__.py
+++ b/burpa/__version__.py
@@ -1,2 +1,2 @@
 __author__ = 'Adel "0x4d31" Karimi, and other contributors'
-__version__ = '0.3.5'
+__version__ = '0.3.6'

--- a/burpa/_api_base.py
+++ b/burpa/_api_base.py
@@ -41,7 +41,7 @@ class ApiBase:
             r.raise_for_status()
         
         except requests.exceptions.RequestException as e:
-            raise BurpaError(f"HTTP Error: {e}. Response: {getattr(e.response, 'text', 'None')}", response=e.response) from e
+            raise BurpaError(f"HTTP Error: {e}. Response: {getattr(e.response, 'text', 'None')}") from e
         
         else:
             return r

--- a/burpa/_api_base.py
+++ b/burpa/_api_base.py
@@ -41,7 +41,7 @@ class ApiBase:
             r.raise_for_status()
         
         except requests.exceptions.RequestException as e:
-            raise BurpaError(f"HTTP Error: {e}. Response: {r.text if r is not None else 'None'}", response=r) from e
+            raise BurpaError(f"HTTP Error: {e}. Response: {getattr(e.response, 'text', 'None')}", response=e.response) from e
         
         else:
             return r

--- a/burpa/_api_base.py
+++ b/burpa/_api_base.py
@@ -41,7 +41,7 @@ class ApiBase:
             r.raise_for_status()
         
         except requests.exceptions.RequestException as e:
-            raise BurpaError(f"HTTP Error: {e}. Response: {r.text if r is not None else 'None'}") from e
+            raise BurpaError(f"HTTP Error: {e}. Response: {r.text if r is not None else 'None'}", response=r) from e
         
         else:
             return r

--- a/burpa/_burpa.py
+++ b/burpa/_burpa.py
@@ -421,8 +421,6 @@ class Burpa:
         """
         
         # start at ID 3 and load all scan statuses until we get a BurpaError. 
-        # If the the error.response.status_code == 400 it means we reached the end of the scan list.
-        # If it's something else, then raise the execption. 
 
         tasks: Dict[str, str] = {}
         current_task_id = 3
@@ -430,10 +428,7 @@ class Burpa:
             try:
                 task_status = self._newapi.scan_status(str(current_task_id))
             except BurpaError as e:
-                if e.response is not None and e.response.status_code==400:
-                    break
-                else:
-                    raise
+                break
             else:
                 tasks[str(current_task_id)] = task_status
                 current_task_id += 1

--- a/burpa/_error.py
+++ b/burpa/_error.py
@@ -1,7 +1,12 @@
 
+from typing import Optional
+import requests
+
 class BurpaError(Exception):
     """
     Exception raised when there is an error in a burpa command. 
     """
-    pass
+    def __init__(self, *args: object, response:Optional[requests.Response]=None) -> None:
+        super().__init__(*args)
+        self.response = response
 

--- a/burpa/_error.py
+++ b/burpa/_error.py
@@ -6,7 +6,5 @@ class BurpaError(Exception):
     """
     Exception raised when there is an error in a burpa command. 
     """
-    def __init__(self, *args: object, response:Optional[requests.Response]=None) -> None:
-        super().__init__(*args)
-        self.response = response
+    
 


### PR DESCRIPTION
Replace the implementation based on filelocks by doing many API calls.
It's longer but safer at the end of the day. It's only used in 'burpa stop' command.