### PR TITLE
Calling _start_scan is missing config_file arg

### DIFF
--- a/burpa/_burpa.py
+++ b/burpa/_burpa.py
@@ -318,7 +318,7 @@ class Burpa:
         if not targets:
             raise BurpaError("Error: No target(s) specified. ")
 
-        records = self._start_scan(*targets, excluded=excluded, config=config, 
+        records = self._start_scan(*targets, excluded=excluded, config=config, config_file=config_file,
                         app_user=app_user, app_pass=app_pass)
         
         self._wait_scan(*records)


### PR DESCRIPTION
When configuration is passed in a file, it is never passed to the _start_scan method. From then on, the new burp api receives it just fine.