### PR TITLE
Issue #25 Added ability to get the report filename

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push:
-    branches: '*'
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         python setup.py install
 
     - name: Run mypy
-      run: tox -p mypy
-      
+      run: tox -e mypy
+
     - name: Run pytype
-      run: tox -p pytype
+      run: tox -e pytype

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,8 @@ jobs:
         python -m pip install wheel tox
         python setup.py install
 
-    - name: Run tests
-      run: tox -p all
+    - name: Run mypy
+      run: tox -p mypy
+      
+    - name: Run pytype
+      run: tox -p pytype

--- a/burpa/__version__.py
+++ b/burpa/__version__.py
@@ -1,2 +1,2 @@
 __author__ = 'Adel "0x4d31" Karimi, and other contributors'
-__version__ = '0.3.9'
+__version__ = '0.3.10'

--- a/burpa/_burpa.py
+++ b/burpa/_burpa.py
@@ -339,7 +339,7 @@ class Burpa:
             # Raise error if a scan failed
             caption = record.metrics['crawl_and_audit_caption']
             if record.status == "paused":
-                raise BurpaError(f"Scan aborted - {record.target_url} : {caption}")
+                raise BurpaError(f"Scan aborted - {record.target_url} : {caption}", records= records)
             elif record.status == "failed":
                 raise BurpaError(f"Scan failed - {record.target_url} : {caption}")
 

--- a/burpa/_burpa.py
+++ b/burpa/_burpa.py
@@ -341,7 +341,7 @@ class Burpa:
             if record.status == "paused":
                 raise BurpaError(f"Scan aborted - {record.target_url} : {caption}", records= records)
             elif record.status == "failed":
-                raise BurpaError(f"Scan failed - {record.target_url} : {caption}")
+                raise BurpaError(f"Scan failed - {record.target_url} : {caption}", records= records)
 
         return records
 

--- a/burpa/_burpa.py
+++ b/burpa/_burpa.py
@@ -349,7 +349,7 @@ class Burpa:
                 report_output_dir: Optional[str] = None, 
                 issue_severity:Union[str, Tuple[str, ...]]="All", 
                 issue_confidence:Union[str, Tuple[str, ...]]="All", 
-                csv:bool=False) -> List:
+                csv:bool=False) -> List[str]:
 
         report_path_list = []
         issues = self._api.scan_issues(target)

--- a/burpa/_burpa.py
+++ b/burpa/_burpa.py
@@ -109,6 +109,8 @@ class Burpa:
         
         self._logger = setup_logger('Burpa', verbose=verbose or bool(os.getenv("BURPA_DEBUG")), quiet=quiet)
 
+        self.report_file_name = None
+
         if not quiet and not no_banner:
             print(ASCII)
         
@@ -374,10 +376,10 @@ class Burpa:
                 filename_template = "burp-report_{}_{}.{}"
             
             # Write the response body (byte array) to file
-            report_file_name = get_valid_filename(filename_template.format(
+            self.report_file_name = get_valid_filename(filename_template.format(
                 report_file_datetime_string, target, report_type.lower()))
 
-            csv_file = os.path.join(report_output_dir or tempfile.gettempdir(), report_file_name)
+            csv_file = os.path.join(report_output_dir or tempfile.gettempdir(), self.report_file_name)
             with open(csv_file, 'w', encoding='utf8') as output_file:
             
                 self._api.write_report(

--- a/burpa/_burpa.py
+++ b/burpa/_burpa.py
@@ -336,12 +336,12 @@ class Burpa:
                         issue_confidence=issue_confidence, 
                         csv=csv, )
                         
-            # Raise error if a scan failed
-            caption = record.metrics['crawl_and_audit_caption']
-            if record.status == "paused":
-                raise BurpaError(f"Scan aborted - {record.target_url} : {caption}", records= records)
-            elif record.status == "failed":
-                raise BurpaError(f"Scan failed - {record.target_url} : {caption}", records= records)
+        # Raise error if a scan failed
+        caption = record.metrics['crawl_and_audit_caption']
+        if record.status == "paused":
+            raise BurpaError(f"Scan aborted - {record.target_url} : {caption}", records= records)
+        elif record.status == "failed":
+            raise BurpaError(f"Scan failed - {record.target_url} : {caption}", records= records)
 
         return records
 

--- a/burpa/_burpa.py
+++ b/burpa/_burpa.py
@@ -327,6 +327,7 @@ class Burpa:
 
         self._scan_metrics(*records)
 
+        reportError = None
         for record in records:
             # Download the scan issues/reports
             if report_type.lower() != 'none':
@@ -335,14 +336,18 @@ class Burpa:
                         issue_severity=issue_severity, 
                         issue_confidence=issue_confidence, 
                         csv=csv, )
-                        
-        # Raise error if a scan failed
-        caption = record.metrics['crawl_and_audit_caption']
-        if record.status == "paused":
-            raise BurpaError(f"Scan aborted - {record.target_url} : {caption}", records= records)
-        elif record.status == "failed":
-            raise BurpaError(f"Scan failed - {record.target_url} : {caption}", records= records)
 
+
+            # Raise error if a scan failed
+            caption = record.metrics['crawl_and_audit_caption']
+            if record.status == "paused":
+               reportError = f"Scan aborted - {record.target_url} : {caption}"
+            elif record.status == "failed":
+                reportError = f"Scan failed - {record.target_url} : {caption}"
+
+        if reportError:
+            raise BurpaError(reportError, records= records)
+        
         return records
 
     def _report(self, target: str, report_type: str, 

--- a/burpa/_burpa.py
+++ b/burpa/_burpa.py
@@ -414,7 +414,7 @@ class Burpa:
                report_output_dir: str = "", 
                issue_severity: Union[str, Tuple[str, ...]]="All", 
                issue_confidence: Union[str, Tuple[str, ...]]="All", 
-               csv: bool=False) -> List:
+               csv: bool=False) -> List[str]:
         """
         Generate the reports for the specified targets URLs.
         If targets is 'all', generate a report that contains all issues for all targets.  

--- a/burpa/_error.py
+++ b/burpa/_error.py
@@ -1,4 +1,16 @@
+from typing import TYPE_CHECKING, Optional, List
+
+if TYPE_CHECKING:
+    from ._burpa import ScanRecord
+
 class BurpaError(Exception):
     """
     Exception raised when there is an error in a burpa command. 
     """
+    def __init__(self, msg: str, records:Optional[List['ScanRecord']]=None) -> None:
+        super().__init__(msg)
+        self.records = records
+        """
+        If the burp scan ended in a failed state, this attribute will old 
+        a list of scan records. They can still contain some valuable informations.
+        """


### PR DESCRIPTION
 When automating it may be advantageous to know with high certainty what the report filename is for further processing (eg XML -> anything).  

This changes the local variable report_file_name to a class property report_file_name.

eg:
burp = Burpa( ... )
burp.scan( ... )
do_more_processing_on_report_file(burp.report_file_name)
