### PR TITLE
Fix Swagger wrong endpoint 

### DIFF
--- a/burpa/_burp_rest_api_client.py
+++ b/burpa/_burp_rest_api_client.py
@@ -118,7 +118,7 @@ class BurpRestApiClient(ApiBase):
                          ),
         
         "docs": (  "get", 
-                         "/v2/api-docs",
+                         "/v3/api-docs",
                          None
                          ),
         


### PR DESCRIPTION
<img width="2553" height="545" alt="image" src="https://github.com/user-attachments/assets/ccaf0772-1515-4fa5-ac16-0ad3f6ccb9fa" />


Burpa try to reach the old swagger endpoint

https://github.com/vmware/burp-rest-api Have now the swagger V3 endpoint